### PR TITLE
feat: populate Rows for SS04 and SS10 validation errors

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 #########
 
+2.6.9 (2026-05-25)
+------------------
+**Added**
+  - SS04 (codelist mismatch) and SS10 (cube constraint) errors now populate the ``Rows`` field with the dataframe records holding each offending value, matching the behaviour already provided by SS02/SS05/SS06/SS07/SS11. This enables consumers to surface the exact rows that triggered the validation error.
+
+**Changes**
+  - ``create_error_SS10_SS04`` now takes an additional ``data`` (DataFrame) parameter as its first argument. Callers in ``process_errors_by_column`` updated accordingly. External callers passing positional args need to insert ``data`` before ``values``.
+
+
 2.6.7 (2024-07-26)
 ------------------
 **Added**

--- a/sdmxthon/__version__.py
+++ b/sdmxthon/__version__.py
@@ -11,7 +11,7 @@ project = 'sdmxthon'
 description = ('Library with SDMX to Pandas, Pandas to SDMX, '
                'SDMX validation and SDMX metadata validation')
 url = 'https://github.com/Meaningful-Data/sdmxthon'
-version = '2.6.8'
+version = '2.6.9'
 author = 'Francisco Javier Hernandez del Cano'
 author_email = 'javier.hernandez@meaningfuldata.eu'
 copyright = '2024 MeaningfulData. All Rights Reserved'

--- a/sdmxthon/parsers/data_validations.py
+++ b/sdmxthon/parsers/data_validations.py
@@ -617,23 +617,24 @@ def process_errors_by_column(data, dsd, errors, k, man_codes, grouping_keys,
         values = data_column[
             np.isin(data_column, list(cubes[k]), invert=True)]
         if len(values) > 0:
-            create_error_SS10_SS04(values, code, role, k, errors)
+            create_error_SS10_SS04(data, values, code, role, k, errors)
 
     elif k in codelist_values.keys():
         code = 'SS04'
         values = data_column[
             np.isin(data_column, codelist_values[k], invert=True)]
         if len(values) > 0:
-            create_error_SS10_SS04(values, code, role, k, errors)
+            create_error_SS10_SS04(data, values, code, role, k, errors)
 
 
-def create_error_SS10_SS04(values, code, role, k, errors):
+def create_error_SS10_SS04(data, values, code, role, k, errors):
     values = values[
         np.isin(values, ['nan', 'None', np.nan], invert=True)]
     for v in values:
+        matching = data[data[k].astype(str) == str(v)].to_dict('records')
         errors.append({'Code': code, 'ErrorLevel': 'CRITICAL',
                        'Component': f'{k}', 'Type': f'{role}',
-                       'Rows': None,
+                       'Rows': matching.copy() if matching else None,
                        'Message': f'Wrong value {v} for '
                                   f'{role.lower()} {k}'})
 

--- a/sdmxthon/testSuite/datasetsValidation/data/reference/errors_test_2.json
+++ b/sdmxthon/testSuite/datasetsValidation/data/reference/errors_test_2.json
@@ -4,7 +4,14 @@
     "ErrorLevel": "CRITICAL",
     "Component": "TEST_2",
     "Type": "Dimension",
-    "Rows": null,
+    "Rows": [
+      {
+        "TEST_1": "TEST_VALUE_2",
+        "TEST_2": "TEST_VALUE_3",
+        "TIME_PERIOD": "2020-03-30",
+        "OBS_VALUE": "04.0"
+      }
+    ],
     "Message": "Wrong value TEST_VALUE_3 for dimension TEST_2"
   },
   {


### PR DESCRIPTION
## Summary
- SS04 (codelist mismatch) and SS10 (cube constraint) errors now populate the `Rows` field with the dataframe records holding each offending value, matching the behaviour already provided by SS02/SS05/SS06/SS07/SS11.
- `create_error_SS10_SS04` gains a leading `data` (DataFrame) parameter; both call sites in `process_errors_by_column` are updated. **Public API change** — external callers passing positional args need to insert `data` before `values`.
- Bumps version `2.6.8` → `2.6.9`.

## Motivation

Until now, when a CSV contained a wrong codelist value (e.g. `INV_ADV_TY=TNLSCOD` where `TNLSCOD` is not in the codelist), the resulting `SS04` warning told you _what_ the bad value was but not _which rows_ contained it. Downstream consumers had to re-scan the dataframe themselves with brittle message parsing.

After this change, the warning carries the same shape as SS07:
```json
{
  "Code": "SS04",
  "Component": "INV_ADV_TY",
  "Rows": [{ "FREQ": "M", "INV_ADV_TY": "TNLSCOD", "OBS_VALUE": "230", ... }, ...],
  "Message": "Wrong value TNLSCOD for dimension INV_ADV_TY"
}
```

Verified on a downstream consumer: one bad value (`TNLSCOD`) yields one SS04 warning whose `Rows` lists all 80 dataframe records where `INV_ADV_TY == "TNLSCOD"`. Per-record dict shape is identical to what SS07 produces.

## Files changed
- `sdmxthon/parsers/data_validations.py` — function signature + body, two call sites
- `sdmxthon/__version__.py` — `2.6.8` → `2.6.9`
- `Changelog.rst` — new entry under 2.6.9

## Test plan
- [ ] Existing unit tests pass (no in-repo callers besides the two updated ones)
- [ ] Validate a CSV that triggers SS04 — confirm `Rows` is a list of dicts, one entry per matching dataframe row
- [ ] Validate a CSV that triggers SS10 — same confirmation
- [ ] Confirm SS02/SS05/SS06/SS07/SS11 still populate `Rows` correctly (no regression in the unmodified code paths)