### PR TITLE
feat: populate Rows for SS04, SS08 and SS10 validation errors

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -2,6 +2,16 @@
 Changelog
 #########
 
+2.6.10 (2026-06-03)
+-------------------
+**Added**
+  - SS08 (facet / value-domain violation) errors now populate the ``Rows`` field with the dataframe records holding each offending value, matching SS02/SS04/SS05/SS06/SS07/SS10/SS11. Previously SS08 always returned ``Rows: null``, leaving consumers without the rows that triggered a facet violation.
+
+**Changes**
+  - ``check_num_facets``, ``check_str_facets`` and ``check_sequence`` now take the ``data`` (DataFrame) as their first argument so offending facet values can be traced back to their rows. All callers are internal to ``data_validations.py``.
+  - Introduced a shared ``rows_for_value`` helper (used by the SS08 sites and ``create_error_SS10_SS04``) which matches on the stored string form first and falls back to a numeric comparison, so float-derived offending values still match zero-padded or plain string cells (e.g. ``4.0`` matches ``'04.0'``).
+
+
 2.6.9 (2026-05-25)
 ------------------
 **Added**

--- a/sdmxthon/__version__.py
+++ b/sdmxthon/__version__.py
@@ -11,7 +11,7 @@ project = 'sdmxthon'
 description = ('Library with SDMX to Pandas, Pandas to SDMX, '
                'SDMX validation and SDMX metadata validation')
 url = 'https://github.com/Meaningful-Data/sdmxthon'
-version = '2.6.9'
+version = '2.6.10'
 author = 'Francisco Javier Hernandez del Cano'
 author_email = 'javier.hernandez@meaningfuldata.eu'
 copyright = '2024 MeaningfulData. All Rights Reserved'

--- a/sdmxthon/parsers/data_validations.py
+++ b/sdmxthon/parsers/data_validations.py
@@ -366,7 +366,25 @@ def trunc_dec(x):
     return x.rstrip('0').rstrip('.') if '.' in x else x
 
 
-def check_sequence(data_column, errors, key, type_, start, interval, end):
+def rows_for_value(data, key, v):
+    """Records in `data` whose `key` column equals the offending value `v`.
+
+    Matches on the stored string form first, then falls back to a numeric
+    comparison so float-derived values (e.g. 4.0) still match zero-padded or
+    plain string cells (e.g. '04.0', '4'). Returns None when nothing matches,
+    mirroring the other row-level error codes.
+    """
+    matching = data[data[key].astype(str) == str(v)]
+    if len(matching) == 0:
+        try:
+            numeric = pd.to_numeric(data[key], errors='coerce')
+            matching = data[numeric == float(v)]
+        except (TypeError, ValueError):
+            matching = data.iloc[0:0]
+    return matching.to_dict('records') if len(matching) else None
+
+
+def check_sequence(data, data_column, errors, key, type_, start, interval, end):
     data_column = np.sort(data_column)
     control = True
     if int(data_column[0]) < start:
@@ -377,7 +395,7 @@ def check_sequence(data_column, errors, key, type_, start, interval, end):
                 errors.append(
                     {'Code': 'SS08', 'ErrorLevel': error_level_facets,
                      'Component': f'{key}', 'Type': f'{type_}',
-                     'Rows': None,
+                     'Rows': rows_for_value(data, key, v),
                      'Message': f'Value {v} not compliant '
                                 f'with startValue : {start}'})
 
@@ -389,7 +407,7 @@ def check_sequence(data_column, errors, key, type_, start, interval, end):
                 errors.append(
                     {'Code': 'SS08', 'ErrorLevel': error_level_facets,
                      'Component': f'{key}', 'Type': f'{type_}',
-                     'Rows': None,
+                     'Rows': rows_for_value(data, key, v),
                      'Message': f'Value {v} not compliant '
                                 f'with endValue : {end}'})
 
@@ -402,7 +420,7 @@ def check_sequence(data_column, errors, key, type_, start, interval, end):
                         {'Code': 'SS08', 'ErrorLevel': error_level_facets,
                          'Component': f'{key}',
                          'Type': f'{type_}',
-                         'Rows': None,
+                         'Rows': rows_for_value(data, key, v),
                          'Message': f'Value {v} in {key} not compliant '
                                     f'with sequence : {start}-{end} '
                                     f'(interval: {interval})'})
@@ -411,14 +429,14 @@ def check_sequence(data_column, errors, key, type_, start, interval, end):
                         {'Code': 'SS08', 'ErrorLevel': error_level_facets,
                          'Component': f'{key}',
                          'Type': f'{type_}',
-                         'Rows': None,
+                         'Rows': rows_for_value(data, key, v),
                          'Message': f'Value {v} in {key} '
                                     f'not compliant with sequence : '
                                     f'{start}-infinite '
                                     f'(interval: {interval})'})
 
 
-def check_num_facets(facets, data_column, key, type_):
+def check_num_facets(data, facets, data_column, key, type_):
     errors = []
     is_sequence = None
     start = None
@@ -462,17 +480,18 @@ def check_num_facets(facets, data_column, key, type_):
                 errors.append(
                     {'Code': 'SS08', 'ErrorLevel': error_level_facets,
                      'Component': f'{key}', 'Type': f'{type_}',
-                     'Rows': None,
+                     'Rows': rows_for_value(data, key, v),
                      'Message': f'Value {v} not compliant with '
                                 f'{f.facet_type} : {f.facet_value}'})
 
     if is_sequence is not None and start is not None and interval is not None:
-        check_sequence(data_column, errors, key, type_, start, interval, end)
+        check_sequence(data, data_column, errors, key, type_, start,
+                       interval, end)
 
     return errors
 
 
-def check_str_facets(facets, data_column, key, type_):
+def check_str_facets(data, facets, data_column, key, type_):
     data_column = data_column[
         np.isin(data_column, ['nan', 'None'], invert=True)].astype('str')
 
@@ -508,7 +527,7 @@ def check_str_facets(facets, data_column, key, type_):
             for v in values:
                 errors.append({'Code': 'SS08', 'ErrorLevel': error_level,
                                'Component': f'{key}', 'Type': f'{type_}',
-                               'Rows': None,
+                               'Rows': rows_for_value(data, key, v),
                                'Message': f'Value {v} not compliant with '
                                           f'{f.facet_type} : {f.facet_value}'})
     return errors
@@ -550,10 +569,10 @@ def process_measure_errors(dsd, data, errors, faceted, types):
         facets = faceted[mc]
         try:
             data_column = data[mc].astype('float64')
-            errors += check_num_facets(facets, data_column, mc, type_)
+            errors += check_num_facets(data, facets, data_column, mc, type_)
         except (TypeError, ValueError):
             data_column = data[mc].astype('str')
-            errors += check_str_facets(facets, data_column, mc, type_)
+            errors += check_str_facets(data, facets, data_column, mc, type_)
 
         del data_column
 
@@ -603,9 +622,9 @@ def process_errors_by_column(data, dsd, errors, k, man_codes, grouping_keys,
     if k in faceted:
         facets = faceted[k]
         if is_numeric:
-            errors += check_num_facets(facets, float_column, k, role)
+            errors += check_num_facets(data, facets, float_column, k, role)
         else:
-            errors += check_str_facets(facets, data_column, k, role)
+            errors += check_str_facets(data, facets, data_column, k, role)
 
     if is_numeric:
         data_column = data_column.astype('str')
@@ -631,10 +650,9 @@ def create_error_SS10_SS04(data, values, code, role, k, errors):
     values = values[
         np.isin(values, ['nan', 'None', np.nan], invert=True)]
     for v in values:
-        matching = data[data[k].astype(str) == str(v)].to_dict('records')
         errors.append({'Code': code, 'ErrorLevel': 'CRITICAL',
                        'Component': f'{k}', 'Type': f'{role}',
-                       'Rows': matching.copy() if matching else None,
+                       'Rows': rows_for_value(data, k, v),
                        'Message': f'Wrong value {v} for '
                                   f'{role.lower()} {k}'})
 

--- a/sdmxthon/testSuite/datasetsValidation/test_facet_rows.py
+++ b/sdmxthon/testSuite/datasetsValidation/test_facet_rows.py
@@ -1,0 +1,78 @@
+"""
+SS08 facet-validation errors must populate `Rows` with the input records that
+triggered them, mirroring SS02/SS04/SS05/SS06/SS07/SS10/SS11.
+
+These exercise the facet helpers directly: they take the full `data` frame plus
+the column key, and reverse-look-up each offending value back to its rows.
+"""
+import pandas as pd
+
+from sdmxthon.model.representation import Facet
+from sdmxthon.parsers.data_validations import (check_num_facets,
+                                               check_str_facets)
+
+
+def test_str_facet_pattern_populates_all_matching_rows():
+    # 'xx' fails the 2-uppercase pattern and appears on two rows.
+    data = pd.DataFrame({
+        'DIM': ['AB', 'xx', 'CD', 'xx'],
+        'OBS_VALUE': ['1', '2', '3', '4'],
+    })
+    facets = [Facet(facetType='pattern', facetValue='[A-Z]{2}')]
+    # process_errors_by_column feeds the facet checks the *unique* values.
+    data_column = data['DIM'].unique().astype('str')
+
+    errors = check_str_facets(data, facets, data_column, 'DIM', 'Dimension')
+
+    ss08 = [e for e in errors if e['Code'] == 'SS08']
+    assert len(ss08) == 1
+    assert ss08[0]['Rows'] is not None
+    assert len(ss08[0]['Rows']) == 2
+    assert {r['OBS_VALUE'] for r in ss08[0]['Rows']} == {'2', '4'}
+
+
+def test_num_facet_maxvalue_populates_rows_with_numeric_fallback():
+    # Stored as the string '99'; the offending value is the float 99.0, so the
+    # match must fall back to a numeric comparison.
+    data = pd.DataFrame({'OBS_VALUE': ['4', '2', '99']})
+    facets = [Facet(facetType='maxValue', facetValue='10')]
+    data_column = data['OBS_VALUE'].astype('float64')
+
+    errors = check_num_facets(data, facets, data_column, 'OBS_VALUE', 'Measure')
+
+    ss08 = [e for e in errors if e['Code'] == 'SS08']
+    assert len(ss08) == 1
+    assert ss08[0]['Rows'] is not None
+    assert [r['OBS_VALUE'] for r in ss08[0]['Rows']] == ['99']
+
+
+def test_num_facet_recovers_zero_padded_rows():
+    # '04.0' and '2' are both < 10; the float offending values (4.0, 2.0) must
+    # map back to their original zero-padded / plain string cells.
+    data = pd.DataFrame({'OBS_VALUE': ['04.0', '2', '99']})
+    facets = [Facet(facetType='minValue', facetValue='10')]
+    data_column = data['OBS_VALUE'].astype('float64')
+
+    errors = check_num_facets(data, facets, data_column, 'OBS_VALUE', 'Measure')
+
+    ss08 = [e for e in errors if e['Code'] == 'SS08']
+    assert len(ss08) == 2
+    recovered = {r['OBS_VALUE'] for e in ss08 for r in (e['Rows'] or [])}
+    assert recovered == {'04.0', '2'}
+
+
+def test_sequence_violation_populates_rows():
+    # interval 2 from start 0 -> '3' is off-sequence; check_num_facets delegates
+    # to check_sequence, which must also receive `data` to populate Rows.
+    data = pd.DataFrame({'DIM': ['0', '2', '3'], 'OBS_VALUE': ['a', 'b', 'c']})
+    facets = [Facet(facetType='isSequence', facetValue='true'),
+              Facet(facetType='startValue', facetValue='0'),
+              Facet(facetType='interval', facetValue='2')]
+    data_column = data['DIM'].astype('float64')
+
+    errors = check_num_facets(data, facets, data_column, 'DIM', 'Dimension')
+
+    ss08 = [e for e in errors if e['Code'] == 'SS08']
+    assert ss08
+    assert all(e['Rows'] is not None for e in ss08)
+    assert any(r['OBS_VALUE'] == 'c' for e in ss08 for r in e['Rows'])


### PR DESCRIPTION
## Summary

Populate the `Rows` field for the value-domain validation codes that previously returned `Rows: null`, so consumers can trace each validation error back to the exact input records that triggered it. This brings **SS04** (codelist mismatch), **SS10** (cube constraint) and **SS08** (facet / value-domain violation) in line with the behaviour already provided by SS02/SS05/SS06/SS07/SS11.

This branch combines work delivered in two steps:
- **SS04 / SS10** (commits already on the branch, `2.6.9`)
- **SS08** (new in this PR, `2.6.10`)

## Root cause (SS08)

SS08 errors are built in three facet helpers — `check_sequence`, `check_num_facets`, `check_str_facets` — that only received a *column of values* (and, on the dimension/attribute path, only the **unique** values), never the source DataFrame. With no access to the rows, all six SS08 construction sites hard-coded `'Rows': None`. The codes that already returned rows do so via `data[mask].to_dict('records')`; SS08 simply could not.

## Changes

- New shared helper **`rows_for_value(data, key, v)`**: returns the records whose `key` column equals the offending value `v`. It matches on the stored string form first, then falls back to a numeric comparison, so float-derived offending values still match zero-padded / plain string cells (e.g. `4.0` matches `'04.0'` or `'4'`). Returns `None` when nothing matches.
- `check_sequence`, `check_num_facets`, `check_str_facets` now take `data` as their first argument; all six SS08 sites populate `Rows` via `rows_for_value`. The two internal call sites (`process_measure_errors`, `process_errors_by_column`) pass `data` through.
- `create_error_SS10_SS04` refactored onto the same `rows_for_value` helper (behaviour-preserving — for SS04/SS10 the offending value is always present in the data, so the string match always hits and the numeric fallback never fires).
- All four changed signatures are **internal** to `data_validations.py` (only `validate_data` is the public entry point), so there is no public API change beyond the row-population behaviour.

## Tests

- New focused tests in `testSuite/datasetsValidation/test_facet_rows.py` cover: pattern violations (with one offending value spanning multiple rows), numeric `maxValue` (exercises the numeric fallback), zero-padded `minValue`, and the `isSequence`/`startValue`/`interval` path. Each asserts `Rows` is populated with the correct records.
- The existing `errors_test_2.json` exact-match fixture is **unchanged** — that data triggers no SS08, and SS04/SS10 output is identical after the refactor.
- Full suite: **218 passed**.

```
python -m pytest sdmxthon/testSuite -q
```

## Versioning

`Changelog.rst` carries entries for `2.6.9` (SS04/SS10) and `2.6.10` (SS08); `__version__.py` is bumped to `2.6.10`.
