### PR TITLE
ci: scope Slack notifications to master, stop PR-push spam

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -2,7 +2,12 @@ name: Slack Notification
 
 on:
   push:
+    branches: [ "master" ]
   pull_request:
+    branches: [ "master" ]
+    # Notify on PRs to master (open / reopen / merge-or-close) but NOT on
+    # 'synchronize' so pushing new commits to a PR branch is not announced.
+    types: [ opened, reopened, closed ]
   issues:
     types: [opened, closed, reopened, edited, deleted, pinned, unpinned, assigned, unassigned, labeled, unlabeled, milestoned, demilestoned]
   issue_comment:


### PR DESCRIPTION
## Summary

Stops the **Slack Notification** workflow from spamming on pushes to PR branches, and scopes it to master, while keeping pull-request-to-master announcements.

## Problem

`slack.yml` triggered on:
- `push:` — **every** branch, so every push to a feature/PR branch announced "pushed new changes".
- `pull_request:` — **every** branch and **all** activity types, including `synchronize`, which fires whenever new commits are pushed to a PR.

So pushing commits to a PR produced **two** Slack notifications (the failing + passing `notify_slack` pair visible on PR checks).

## Change

```yaml
on:
  push:
    branches: [ "master" ]
  pull_request:
    branches: [ "master" ]
    types: [ opened, reopened, closed ]
```

- **push** → only `master` (merges / direct pushes), no feature/PR-branch noise.
- **pull_request** → only PRs targeting `master`, and only `opened` / `reopened` / `closed` (drops `synchronize`), so pushing commits to a PR branch is no longer announced.
- `issues`, `issue_comment`, `create`, `delete` triggers are unchanged.

## Net behaviour

| Event | Before | After |
|-------|--------|-------|
| Push to a PR/feature branch | 🔔 (push + synchronize) | — |
| Open / reopen a PR to master | 🔔 | 🔔 |
| Merge a PR to master | 🔔 | 🔔 |
| Push / merge to master | 🔔 | 🔔 |

## Note

`testing.yml` (the `testing-and-flake8` CI) already triggers on `pull_request: [ "master" ]`, so PRs to master are already tested — no change needed there.

> Workflow-trigger changes take effect once this is on `master` (GitHub evaluates `pull_request` triggers from the base branch).
