### PR TITLE
feat: populate Rows for SS09 date/time-format validation errors

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 #########
 
+2.6.11 (2026-06-03)
+-------------------
+**Added**
+  - SS09 (invalid date / time-format value) errors now populate the ``Rows`` field with the dataframe records holding each offending value, matching SS02/SS04/SS05/SS06/SS07/SS08/SS10/SS11. Previously SS09 always returned ``Rows: null``. SS09 was the last row-tied validation code still missing its rows.
+
+**Changes**
+  - ``error_SS09`` and ``create_error_SS09`` now take the ``data`` (DataFrame) as their first argument so offending time/date values can be traced back to their rows (reusing the ``rows_for_value`` helper). All callers are internal to ``data_validations.py``.
+
+
 2.6.10 (2026-06-03)
 -------------------
 **Added**

--- a/sdmxthon/__version__.py
+++ b/sdmxthon/__version__.py
@@ -11,7 +11,7 @@ project = 'sdmxthon'
 description = ('Library with SDMX to Pandas, Pandas to SDMX, '
                'SDMX validation and SDMX metadata validation')
 url = 'https://github.com/Meaningful-Data/sdmxthon'
-version = '2.6.10'
+version = '2.6.11'
 author = 'Francisco Javier Hernandez del Cano'
 author_email = 'javier.hernandez@meaningfuldata.eu'
 copyright = '2024 MeaningfulData. All Rights Reserved'

--- a/sdmxthon/parsers/data_validations.py
+++ b/sdmxthon/parsers/data_validations.py
@@ -306,20 +306,20 @@ def time_period_valid(dt_str: str, type_: str):
     return process_special_time_format(dt_str)
 
 
-def error_SS09(k, time_types, data_column, errors, role):
+def error_SS09(data, k, time_types, data_column, errors, role):
     if time_types[k] in time_periods:
-        create_error_SS09(data_column, time_types[k], time_types[k], k,
+        create_error_SS09(data, data_column, time_types[k], time_types[k], k,
                           role, errors, time_period_valid)
     elif time_types[k] in gregorian_periods:
         format_ = gregorian_periods[time_types[k]]
-        create_error_SS09(data_column, format_, time_types[k], k,
+        create_error_SS09(data, data_column, format_, time_types[k], k,
                           role, errors, check_date)
 
     elif time_types[k] in reporting_periods:
 
         format_ = r'(19|[2-9][0-9])\d{2}-' + reporting_periods[time_types[k]]
 
-        create_error_SS09(data_column, format_, time_types[k], k,
+        create_error_SS09(data, data_column, format_, time_types[k], k,
                           role, errors, time_period_valid)
 
     elif time_types[k].lower() == "datetime" or time_types[k] == "TimeRange":
@@ -354,7 +354,7 @@ def error_SS09(k, time_types, data_column, errors, role):
                     {'Code': 'SS09', 'ErrorLevel': "CRITICAL",
                      'Component': f'{k}',
                      'Type': f'{role}',
-                     'Rows': None,
+                     'Rows': rows_for_value(data, k, e + duration),
                      'Message': f'Value {e + duration} not compliant '
                                 f'with type : {time_types[k]}'})
             if control_changed:
@@ -617,7 +617,7 @@ def process_errors_by_column(data, dsd, errors, k, man_codes, grouping_keys,
                                       f'{role.lower()} {k}'})
 
     if k in types:
-        error_SS09(k, types, data_column, errors, role)
+        error_SS09(data, k, types, data_column, errors, role)
 
     if k in faceted:
         facets = faceted[k]
@@ -677,15 +677,15 @@ def create_error_SS07(x, rows, errors, grouping_keys):
                    })
 
 
-def create_error_SS09(data_column, format_, time_type, comp, role, errors,
-                      func):
+def create_error_SS09(data, data_column, format_, time_type, comp, role,
+                      errors, func):
     for e in data_column:
         if not func(e, format_):
             errors.append(
                 {'Code': 'SS09', 'ErrorLevel': "CRITICAL",
                  'Component': f'{comp}',
                  'Type': f'{role}',
-                 'Rows': None,
+                 'Rows': rows_for_value(data, comp, e),
                  'Message': f'Value {e} not compliant with '
                             f'type : {time_type}'})
 

--- a/sdmxthon/testSuite/datasetsValidation/test_ss09_rows.py
+++ b/sdmxthon/testSuite/datasetsValidation/test_ss09_rows.py
@@ -1,0 +1,51 @@
+"""
+SS09 (invalid date / time-format value) errors must populate `Rows` with the
+input records that triggered them, like the other row-level codes.
+
+SS09 is built in two places, both of which must reverse-look-up the offending
+value back to its rows:
+  - create_error_SS09 (gregorian / reporting / time-period formats)
+  - the inline datetime / TimeRange branch of error_SS09
+"""
+import pandas as pd
+
+from sdmxthon.parsers.data_validations import create_error_SS09, error_SS09
+
+
+def test_create_error_ss09_populates_all_matching_rows():
+    # '2024-13' fails validation and appears on two rows.
+    data = pd.DataFrame({
+        'TIME_PERIOD': ['2024-01', '2024-13', '2024-13'],
+        'OBS_VALUE': ['1', '2', '3'],
+    })
+    # process_errors_by_column feeds the check the *unique* values.
+    data_column = data['TIME_PERIOD'].unique().astype('str')
+    errors = []
+
+    create_error_SS09(data, data_column, 'fmt', 'GregorianYearMonth',
+                      'TIME_PERIOD', 'Dimension', errors,
+                      lambda e, fmt: e != '2024-13')
+
+    ss09 = [e for e in errors if e['Code'] == 'SS09']
+    assert len(ss09) == 1
+    assert ss09[0]['Rows'] is not None
+    assert len(ss09[0]['Rows']) == 2
+    assert {r['OBS_VALUE'] for r in ss09[0]['Rows']} == {'2', '3'}
+
+
+def test_error_ss09_datetime_branch_populates_rows():
+    # '2024-13-01' is an invalid datetime (month 13) -> SS09 tied to its row.
+    data = pd.DataFrame({
+        'TIME_PERIOD': ['2020-01-01', '2024-13-01'],
+        'OBS_VALUE': ['10', '20'],
+    })
+    data_column = data['TIME_PERIOD'].unique().astype('str')
+    errors = []
+
+    error_SS09(data, 'TIME_PERIOD', {'TIME_PERIOD': 'datetime'},
+               data_column, errors, 'Dimension')
+
+    ss09 = [e for e in errors if e['Code'] == 'SS09']
+    assert len(ss09) == 1
+    assert ss09[0]['Rows'] is not None
+    assert [r['OBS_VALUE'] for r in ss09[0]['Rows']] == ['20']


### PR DESCRIPTION
## Summary

Populate the `Rows` field for **SS09** (invalid date / time-format value) validation errors — the last row-tied code that still returned `Rows: null`. Follows the SS04/SS08/SS10 pattern shipped in 2.6.9 / 2.6.10.

## Root cause

SS09 fires when a specific cell holds an invalid date/time value (bad month, malformed `TimeRange`, a value that doesn't match the dimension's time format), so it is tied to specific rows — but the two builders only received the column of values, never the `data` frame, and hard-coded `'Rows': None`:

- `create_error_SS09` — gregorian / reporting / time-period formats
- the inline `datetime` / `TimeRange` branch of `error_SS09`

## Change

- `error_SS09` and `create_error_SS09` now take `data` (the DataFrame) as their first argument; both build sites populate `Rows` via the existing **`rows_for_value`** helper (introduced in 2.6.10). For the `TimeRange` branch the original cell is reconstructed as `e + duration` before lookup.
- The single call site in `process_errors_by_column` passes `data`.
- All four changed signatures are internal to `data_validations.py` (only `validate_data` is the public entry point), so no public API change beyond the row-population behaviour.

## Tests

New `testSuite/datasetsValidation/test_ss09_rows.py` covers **both** build sites:
- `create_error_SS09` with an offending value spanning multiple rows (asserts all matching rows are returned), and
- the inline `datetime` branch (an invalid month maps back to its row).

Full suite: **220 passed**.

```
python -m pytest sdmxthon/testSuite -q
```

## Versioning

`Changelog.rst` gains a `2.6.11` entry; `__version__.py` bumped `2.6.10` → `2.6.11`.

After this, **every row-tied validation code (SS02/04/05/06/07/08/09/10/11) populates `Rows`.**
